### PR TITLE
Drop linkTitleToSelf

### DIFF
--- a/Documentation/PageTsconfig/TCEform/Index.rst
+++ b/Documentation/PageTsconfig/TCEform/Index.rst
@@ -634,42 +634,6 @@ above).
          100%
 
 
-.. container:: table-row
-
-   Property
-         linkTitleToSelf
-
-   Data type
-         boolean
-
-   Description
-         *(all fields)*
-
-         If set, then the title of the field in the forms links to alt\_doc.php
-         editing ONLY that field.
-
-         Works for existing records only - not for new records.
-
-         **Example:**
-
-         .. code-block:: typoscript
-
-			TCEFORM.pages.title {
-				# The label for the "title" field will link itself
-				linkTitleToSelf = 1
-			}
-
-         The result is that the label for the title field will be a link:
-
-         .. figure:: ../../Images/manual_html_m156d544f.png
-            :alt: The label for the title field turns into a link
-
-         Clicking the link brings you to a form where only this field is shown:
-
-         .. figure:: ../../Images/manual_html_62e7bc5f.png
-            :alt: The Edit Page screen after clicking the link
-
-
 .. ###### END~OF~TABLE ######
 
 [page:TCEFORM.(table name).(field)/TCEFORM.(table name).(field).types.(type)]


### PR DESCRIPTION
TCEFORM."table"."field".linkTitleToSelf can be used in FormEngine to link the
label of a single rendered field to a "sub form" of the displayed row where only
this single field is displayed. This has zero advantage usability wise.
Documentation of this feature is now removed in 6.2 and master, and it will
be dropped code wise in master completely.
